### PR TITLE
LPS-90757 Only owner and admins can do the initial share

### DIFF
--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -107,7 +107,15 @@ public class SharingDLViewFileVersionDisplayContext
 
 	@Override
 	public boolean isSharingLinkVisible() {
-		return _sharingConfiguration.isEnabled();
+		if (_sharingConfiguration.isEnabled() &&
+			_sharingPermissionHelper.isShareable(
+				_themeDisplay.getPermissionChecker(),
+				_fileEntry.getFileEntryId())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isShowActions() throws PortalException {

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/security/permission/SharingPermissionHelper.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/security/permission/SharingPermissionHelper.java
@@ -17,7 +17,6 @@ package com.liferay.sharing.document.library.internal.security.permission;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -38,15 +37,21 @@ import org.osgi.service.component.annotations.Reference;
 public class SharingPermissionHelper {
 
 	public boolean isShareable(
-			PermissionChecker permissionChecker, long fileEntryId)
-		throws PortalException {
+		PermissionChecker permissionChecker, long fileEntryId) {
 
-		if (_dlFileEntryLocalService.fetchDLFileEntry(fileEntryId) == null) {
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
+			fileEntryId);
+
+		if (dlFileEntry == null) {
 			return false;
 		}
 
-		if (_dlFileEntryModelResourcePermission.contains(
-				permissionChecker, fileEntryId, ActionKeys.VIEW)) {
+		if (permissionChecker.isOmniadmin() ||
+			permissionChecker.isCompanyAdmin() ||
+			permissionChecker.isGroupAdmin(dlFileEntry.getGroupId()) ||
+			permissionChecker.hasOwnerPermission(
+				dlFileEntry.getCompanyId(), DLFileEntryConstants.getClassName(),
+				fileEntryId, dlFileEntry.getUserId(), ActionKeys.VIEW)) {
 
 			return true;
 		}


### PR DESCRIPTION
Hey @patriciajeanperez,

Due to some limitations, we need to change the way sharing works. The
new behaviour is:

1. If the user is the owner of a document, or a group/company admin,
he/she can share the document.

2. Otherwise, only if the document has been shared with him as
"shareable" he'll be able to share it.

Previously, any user was able to share any document as long as he had
VIEW permissions. This made it impossible to forbid resharing in some
cases.

Thanks!