### PR TITLE
LPS-91303

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/KBUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/KBUtil.java
@@ -316,6 +316,17 @@ public class KBUtil {
 		return KBCommentConstants.STATUS_NONE;
 	}
 
+	public static List<KBFolder> getRootKBFolders(long groupId, long kbFolderId)
+		throws PortalException {
+
+		List<KBFolder> kbFolders = KBFolderServiceUtil.getKBFolders(
+			groupId, kbFolderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		kbFolders = new ArrayList<>(kbFolders);
+
+		return ListUtil.sort(kbFolders, new KBFolderNameComparator(false));
+	}
+
 	public static long getRootResourcePrimKey(
 			PortletRequest portletRequest, long groupId,
 			long resourceClassNameId, long resourcePrimKey)

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/KBUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/KBUtil.java
@@ -316,17 +316,6 @@ public class KBUtil {
 		return KBCommentConstants.STATUS_NONE;
 	}
 
-	public static List<KBFolder> getRootKBFolders(long groupId, long kbFolderId)
-		throws PortalException {
-
-		List<KBFolder> kbFolders = KBFolderServiceUtil.getKBFolders(
-			groupId, kbFolderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		kbFolders = new ArrayList<>(kbFolders);
-
-		return ListUtil.sort(kbFolders, new KBFolderNameComparator(false));
-	}
-
 	public static long getRootResourcePrimKey(
 			PortletRequest portletRequest, long groupId,
 			long resourceClassNameId, long resourcePrimKey)

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
 import com.liferay.knowledge.base.util.comparator.KBArticlePriorityComparator;
 import com.liferay.knowledge.base.web.internal.KBUtil;
 import com.liferay.knowledge.base.web.internal.configuration.KBDisplayPortletInstanceConfiguration;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -122,6 +123,9 @@ public class KBNavigationDisplayContext {
 				rootResourcePrimKey);
 
 			currentKBFolderURLTitle = kbFolder.getUrlTitle();
+		}
+		else {
+			currentKBFolderURLTitle = StringPool.BLANK;
 		}
 
 		return currentKBFolderURLTitle;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
@@ -115,15 +115,6 @@ public class KBNavigationDisplayContext {
 			_portalPreferences,
 			_kbDisplayPortletInstanceConfiguration.contentRootPrefix());
 
-		long rootResourcePrimKey = getRootResourcePrimKey();
-
-		if (rootResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			KBFolder kbFolder = KBFolderServiceUtil.getKBFolder(
-				rootResourcePrimKey);
-
-			currentKBFolderURLTitle = kbFolder.getUrlTitle();
-		}
-
 		return currentKBFolderURLTitle;
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
@@ -115,6 +115,15 @@ public class KBNavigationDisplayContext {
 			_portalPreferences,
 			_kbDisplayPortletInstanceConfiguration.contentRootPrefix());
 
+		long rootResourcePrimKey = getRootResourcePrimKey();
+
+		if (rootResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			KBFolder kbFolder = KBFolderServiceUtil.getKBFolder(
+				rootResourcePrimKey);
+
+			currentKBFolderURLTitle = kbFolder.getUrlTitle();
+		}
+
 		return currentKBFolderURLTitle;
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java
@@ -170,6 +170,8 @@ public class DisplayPortlet extends BaseKBPortlet {
 			actionRequest, KBPortletKeys.KNOWLEDGE_BASE_DISPLAY,
 			PortletRequest.RENDER_PHASE);
 
+		redirectURL.setParameter("kbFolderId", String.valueOf(kbFolderId));
+
 		redirectURL.setParameter("kbFolderUrlTitle", kbFolderURLTitle);
 
 		if (kbArticle != null) {
@@ -377,6 +379,14 @@ public class DisplayPortlet extends BaseKBPortlet {
 		long parentResourceClassNameId = GetterUtil.getLong(
 			portletPreferences.getValue("resourceClassNameId", null),
 			kbFolderClassNameId);
+
+		long kbFolderId = ParamUtil.getLong(renderRequest, "kbFolderId");
+
+		if ((parentResourceClassNameId == kbFolderClassNameId) &&
+			(kbFolderId != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
+			parentResourcePrimKey = kbFolderId;
+		}
 
 		KBArticleSelector kbArticleSelector =
 			_kbArticleSelectorFactory.getKBArticleSelector(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java
@@ -147,7 +147,7 @@ public class DisplayPortlet extends BaseKBPortlet {
 				kbFolderGroupId, kbFolderURLTitle, urlTitle);
 
 			if ((kbArticle == null) &&
-				(previousPreferredKBFolderURLTitle != null)) {
+				Validator.isNotNull(previousPreferredKBFolderURLTitle)) {
 
 				kbArticle = findClosestMatchingKBArticle(
 					kbFolderGroupId, previousPreferredKBFolderURLTitle,

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java
@@ -30,6 +30,7 @@ import com.liferay.knowledge.base.web.internal.constants.KBWebKeys;
 import com.liferay.knowledge.base.web.internal.selector.KBArticleSelection;
 import com.liferay.knowledge.base.web.internal.selector.KBArticleSelector;
 import com.liferay.knowledge.base.web.internal.selector.KBArticleSelectorFactory;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchSubscriptionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Release;
@@ -105,13 +106,21 @@ public class DisplayPortlet extends BaseKBPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws IOException, PortalException {
 
+		KBFolder kbFolder = null;
+
+		long kbFolderGroupId = _portal.getScopeGroupId(actionRequest);
+
 		long kbFolderId = ParamUtil.getLong(actionRequest, "rootKBFolderId");
 
-		if (kbFolderId == KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			return;
-		}
+		String kbFolderURLTitle = StringPool.BLANK;
 
-		KBFolder kbFolder = kbFolderService.getKBFolder(kbFolderId);
+		if (kbFolderId != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			kbFolder = kbFolderService.getKBFolder(kbFolderId);
+
+			kbFolderGroupId = kbFolder.getGroupId();
+
+			kbFolderURLTitle = kbFolder.getUrlTitle();
+		}
 
 		PortalPreferences portalPreferences =
 			PortletPreferencesFactoryUtil.getPortalPreferences(
@@ -127,7 +136,7 @@ public class DisplayPortlet extends BaseKBPortlet {
 				portalPreferences, contentRootPrefix);
 
 		KnowledgeBaseUtil.setPreferredKBFolderURLTitle(
-			portalPreferences, contentRootPrefix, kbFolder.getUrlTitle());
+			portalPreferences, contentRootPrefix, kbFolderURLTitle);
 
 		String urlTitle = ParamUtil.getString(actionRequest, "urlTitle");
 
@@ -135,14 +144,14 @@ public class DisplayPortlet extends BaseKBPortlet {
 
 		if (Validator.isNotNull(urlTitle)) {
 			kbArticle = _kbArticleLocalService.fetchKBArticleByUrlTitle(
-				kbFolder.getGroupId(), kbFolder.getUrlTitle(), urlTitle);
+				kbFolderGroupId, kbFolderURLTitle, urlTitle);
 
 			if ((kbArticle == null) &&
-				Validator.isNotNull(previousPreferredKBFolderURLTitle)) {
+				(previousPreferredKBFolderURLTitle != null)) {
 
 				kbArticle = findClosestMatchingKBArticle(
-					kbFolder.getGroupId(), previousPreferredKBFolderURLTitle,
-					kbFolder.getKbFolderId(), urlTitle);
+					kbFolderGroupId, previousPreferredKBFolderURLTitle,
+					kbFolderId, urlTitle);
 			}
 		}
 
@@ -161,7 +170,7 @@ public class DisplayPortlet extends BaseKBPortlet {
 			actionRequest, KBPortletKeys.KNOWLEDGE_BASE_DISPLAY,
 			PortletRequest.RENDER_PHASE);
 
-		redirectURL.setParameter("kbFolderUrlTitle", kbFolder.getUrlTitle());
+		redirectURL.setParameter("kbFolderUrlTitle", kbFolderURLTitle);
 
 		if (kbArticle != null) {
 			redirectURL.setParameter("urlTitle", kbArticle.getUrlTitle());

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/content_root_selector.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/content_root_selector.jsp
@@ -23,10 +23,25 @@ KBNavigationDisplayContext kbNavigationDisplayContext = (KBNavigationDisplayCont
 
 String currentKBFolderURLTitle = kbNavigationDisplayContext.getCurrentKBFolderURLTitle();
 
-List<KBFolder> kbFolders = KBUtil.getAlternateRootKBFolders(scopeGroupId, kbDisplayPortletInstanceConfiguration.resourcePrimKey());
+long rootResourcePrimKey = kbDisplayPortletInstanceConfiguration.resourcePrimKey();
+
+long rootKBFolderId = KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+
+String rootKBFolderName = LanguageUtil.get(resourceBundle, "home");
+String rootKBFolderURLTitle = StringPool.BLANK;
+
+if (rootResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+	KBFolder rootKBFolder = KBFolderServiceUtil.getKBFolder(rootResourcePrimKey);
+
+	rootKBFolderId = rootKBFolder.getKbFolderId();
+	rootKBFolderName = rootKBFolder.getName();
+	rootKBFolderURLTitle = rootKBFolder.getUrlTitle();
+}
+
+List<KBFolder> kbFolders = KBUtil.getRootKBFolders(scopeGroupId, kbDisplayPortletInstanceConfiguration.resourcePrimKey());
 %>
 
-<c:if test="<%= kbFolders.size() > 1 %>">
+<c:if test="<%= !kbFolders.isEmpty() %>">
 	<liferay-portlet:actionURL name="updateRootKBFolderId" var="updateRootKBFolderIdURL">
 		<c:if test="<%= kbArticle != null %>">
 			<portlet:param name="urlTitle" value="<%= kbArticle.getUrlTitle() %>" />
@@ -36,6 +51,9 @@ List<KBFolder> kbFolders = KBUtil.getAlternateRootKBFolders(scopeGroupId, kbDisp
 	<div class="kbarticle-root-selector">
 		<aui:form action="<%= updateRootKBFolderIdURL %>" name="updateRootKBFolderIdFm">
 			<aui:select label="" name="rootKBFolderId">
+				<aui:option selected="<%= currentKBFolderURLTitle.equals(rootKBFolderURLTitle) %>" value="<%= rootKBFolderId %>">
+					<%= HtmlUtil.escape(kbDisplayPortletInstanceConfiguration.contentRootPrefix() + " " + rootKBFolderName) %>
+				</aui:option>
 
 				<%
 				for (KBFolder kbFolder : kbFolders) {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/content_root_selector.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/content_root_selector.jsp
@@ -38,7 +38,7 @@ if (rootResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 	rootKBFolderURLTitle = rootKBFolder.getUrlTitle();
 }
 
-List<KBFolder> kbFolders = KBUtil.getRootKBFolders(scopeGroupId, kbDisplayPortletInstanceConfiguration.resourcePrimKey());
+List<KBFolder> kbFolders = KBUtil.getAlternateRootKBFolders(scopeGroupId, kbDisplayPortletInstanceConfiguration.resourcePrimKey());
 %>
 
 <c:if test="<%= !kbFolders.isEmpty() %>">
@@ -51,9 +51,11 @@ List<KBFolder> kbFolders = KBUtil.getRootKBFolders(scopeGroupId, kbDisplayPortle
 	<div class="kbarticle-root-selector">
 		<aui:form action="<%= updateRootKBFolderIdURL %>" name="updateRootKBFolderIdFm">
 			<aui:select label="" name="rootKBFolderId">
-				<aui:option selected="<%= currentKBFolderURLTitle.equals(rootKBFolderURLTitle) %>" value="<%= rootKBFolderId %>">
-					<%= HtmlUtil.escape(kbDisplayPortletInstanceConfiguration.contentRootPrefix() + " " + rootKBFolderName) %>
-				</aui:option>
+				<c:if test="<%= KBArticleServiceUtil.getKBArticlesCount(scopeGroupId, rootKBFolderId, WorkflowConstants.STATUS_APPROVED) > 0 %>">
+					<aui:option selected="<%= currentKBFolderURLTitle.equals(rootKBFolderURLTitle) %>" value="<%= rootKBFolderId %>">
+						<%= HtmlUtil.escape(kbDisplayPortletInstanceConfiguration.contentRootPrefix() + " " + rootKBFolderName) %>
+					</aui:option>
+				</c:if>
 
 				<%
 				for (KBFolder kbFolder : kbFolders) {


### PR DESCRIPTION
Hey @patriciajeanperez,

This changes the behaviour of KB when displaying the contents of a
folder. If the folder has both articles and folders, now it will allow
to see those articles by including the root folder in the navigation.

This shouldn't break any existing tests (as it is a new use case), but
I'm sending this to you anyway just in case.

Thanks!