### PR TITLE
LPS-93180 Sort by modifiedDate by default

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -689,8 +689,12 @@ public class DLImpl implements DL {
 			orderByComparator = new RepositoryModelSizeComparator<>(
 				orderByAsc, orderByModel);
 		}
-		else {
+		else if (orderByCol.equals("title")) {
 			orderByComparator = new RepositoryModelTitleComparator<>(
+				orderByAsc, orderByModel);
+		}
+		else {
+			orderByComparator = new RepositoryModelModifiedDateComparator<>(
 				orderByAsc, orderByModel);
 		}
 


### PR DESCRIPTION
Hey @patriciajeanperez,

Previously used title ordering as the default sort.  I've changed it to order by
modified date instead.

Thanks!