### PR TITLE
LPS-90739 Remove usage of "subcategory"

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEntriesManagementToolbarDisplayContext.java
@@ -206,15 +206,8 @@ public class MBEntriesManagementToolbarDisplayContext {
 						"redirect", _currentURLObj.toString(),
 						"parentCategoryId", String.valueOf(categoryId));
 
-					String label = "category[message-board]";
-
-					if (categoryId !=
-							MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) {
-
-						label = "subcategory[message-board]";
-					}
-
-					dropdownItem.setLabel(LanguageUtil.get(_request, label));
+					dropdownItem.setLabel(
+						LanguageUtil.get(_request, "category[message-board]"));
 				});
 		}
 


### PR DESCRIPTION
Hey @patriciajeanperez,

Here I've removed the usage of "Subcategory" in the plus action button of
message boards.  We'll use "category" for both categories and subcategories.

Thanks!