### PR TITLE
LPS-94075 Use "folder" instead of "subfolder"

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/toolbar/contributor/BookmarksPortletToolbarContributor.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/toolbar/contributor/BookmarksPortletToolbarContributor.java
@@ -130,8 +130,7 @@ public class BookmarksPortletToolbarContributor
 
 		urlMenuItem.setLabel(
 			LanguageUtil.get(
-				_portal.getHttpServletRequest(portletRequest),
-				(folder != null) ? "subfolder" : "folder"));
+				_portal.getHttpServletRequest(portletRequest), "folder"));
 
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/asset/folder_full_content.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/asset/folder_full_content.jsp
@@ -56,7 +56,7 @@ BookmarksFolder folder = (BookmarksFolder)request.getAttribute(BookmarksWebKeys.
 						markupView="lexicon"
 					/>
 
-					<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "subfolder" : "subfolders" %>' />
+					<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "folder" : "folders" %>' />
 				</div>
 
 				<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/folder_full_content.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/folder_full_content.jsp
@@ -42,7 +42,7 @@ Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 	%>
 
 	<div class="small">
-		<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "subfolder" : "subfolders" %>' />
+		<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "folder" : "folders" %>' />
 	</div>
 
 	<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view.jsp
@@ -190,7 +190,7 @@ List fileEntries = DLAppServiceUtil.getGroupFileEntries(scopeGroupId, 0, folderI
 								markupView="lexicon"
 							/>
 
-							<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "subfolder" : "subfolders" %>' />
+							<%= foldersCount %> <liferay-ui:message key='<%= (foldersCount == 1) ? "folder" : "folders" %>' />
 						</div>
 
 						<%


### PR DESCRIPTION
Hey @patriciajeanperez,

We've changed the labels in Bookmarks, so that references to "subfolder"
use now the term "folder".

Thanks!