### PR TITLE
LPS-166931 Renamed last parameters

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountUserMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountUserMVCActionCommand.java
@@ -104,11 +104,11 @@ public class EditAccountUserMVCActionCommand
 
 		accountUserContact.setPrefixListTypeId(
 			_getListTypeId(
-				actionRequest, "prefixListTypeValue",
+				actionRequest, "prefixValue",
 				ListTypeConstants.CONTACT_PREFIX));
 		accountUserContact.setSuffixListTypeId(
 			_getListTypeId(
-				actionRequest, "suffixListTypeValue",
+				actionRequest, "suffixValue",
 				ListTypeConstants.CONTACT_SUFFIX));
 
 		_contactLocalService.updateContact(accountUserContact);

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
@@ -525,15 +525,13 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest);
 
 		long prefixListTypeId = _getListTypeId(
-			actionRequest, "prefixListTypeValue",
-			ListTypeConstants.CONTACT_PREFIX);
+			actionRequest, "prefixValue", ListTypeConstants.CONTACT_PREFIX);
 
 		dynamicActionRequest.setParameter(
 			"prefixListTypeId", String.valueOf(prefixListTypeId));
 
 		long suffixListTypeId = _getListTypeId(
-			actionRequest, "suffixListTypeValue",
-			ListTypeConstants.CONTACT_SUFFIX);
+			actionRequest, "suffixValue", ListTypeConstants.CONTACT_SUFFIX);
 
 		dynamicActionRequest.setParameter(
 			"suffixListTypeId", String.valueOf(suffixListTypeId));

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
@@ -555,15 +555,13 @@ public class EditUserMVCActionCommand
 			actionRequest);
 
 		long prefixListTypeId = _getListTypeId(
-			actionRequest, "prefixListTypeValue",
-			ListTypeConstants.CONTACT_PREFIX);
+			actionRequest, "prefixValue", ListTypeConstants.CONTACT_PREFIX);
 
 		dynamicActionRequest.setParameter(
 			"prefixListTypeId", String.valueOf(prefixListTypeId));
 
 		long suffixListTypeId = _getListTypeId(
-			actionRequest, "suffixListTypeValue",
-			ListTypeConstants.CONTACT_SUFFIX);
+			actionRequest, "suffixValue", ListTypeConstants.CONTACT_SUFFIX);
 
 		dynamicActionRequest.setParameter(
 			"suffixListTypeId", String.valueOf(suffixListTypeId));


### PR DESCRIPTION
This is an update related to [LPS-166931](https://issues.liferay.com/browse/LPS-166931). In order to undo some changes that have caused failures on users and accounts when trying to add a prefix and/or suffix